### PR TITLE
Log CR2 on page fault

### DIFF
--- a/oskernel64/kernel/idt.c
+++ b/oskernel64/kernel/idt.c
@@ -171,6 +171,9 @@ void isr_dispatch_c(isr_frame* f) {
             die_halt("#GP",f);
         case 0x0E:
             printk("PF Page fault");
+            unsigned long cr2;
+            asm volatile("mov %%cr2, %0" : "=r"(cr2));
+            printk("CR2=%x\n", (unsigned long long)cr2);
             decode_pf_err(f->error);
             die_halt("#PF",f);
         default:


### PR DESCRIPTION
## Summary
- log CR2 register for page faults before decoding error

## Testing
- `make build/oskernel64/kernel64.bin`


------
https://chatgpt.com/codex/tasks/task_e_68a853c1ef60833398c5614d6e8a6c62