### PR TITLE
Initialize APIC and register timer interrupt

### DIFF
--- a/oskernel64/include/apic.h
+++ b/oskernel64/include/apic.h
@@ -11,4 +11,6 @@ bool check_APIC_TSC();
 
 void apic_eoi();
 void apic_singleCore_timer_init();
+void apic_timer_isr_c();
+void apic_error_isr_c();
 #endif //APIC_H

--- a/oskernel64/kernel/apic.c
+++ b/oskernel64/kernel/apic.c
@@ -136,11 +136,8 @@ static inline void pic_disable_all() {
 }
 
 // ---------------------- Timer ISR ----------------------
-// extern void isr_apic_timer_stub();
-// extern void isr_apic_error_stub();
-
-void isr_apic_timer_stub() {}
-void isr_apic_error_stub() {}
+extern void isr_0xF0();
+extern void isr_0xFE();
 
 static volatile u64 g_ticks = 0;
 
@@ -174,9 +171,9 @@ void apic_singleCore_timer_init() {
     //3.这里需要映射虚拟地址
 
 
-    //4.配置IDT： 向量0XF0（本地计时器），0xFE（错误中断）
-    // set_idt_gate(0xF0,isr_apic_timer_stub,0,14,0,0x8);
-    // set_idt_gate(0xFE,isr_apic_error_stub,0,14,0,0x8);
+    //4.配置IDT： 向量0xF0（本地计时器），0xFE（错误中断）
+    set_idt_gate(0xF0,isr_0xF0,0,14,0,0x08);
+    set_idt_gate(0xFE,isr_0xFE,0,14,0,0x08);
     idtr.base = (u64)idt;
     idtr.limit = (sizeof idt) -1;
     lidt();
@@ -192,10 +189,10 @@ void apic_singleCore_timer_init() {
     lapic_write(LAPIC_LVT_LINT1, 1u << 16);
     lapic_write(LAPIC_LVT_ERROR, 0xFE);
 
-    // //8.配置本地APIC定时器,div by 16
-    // lapic_write(LAPIC_TIMER_DIV, 0b0011);
-
-
+    //8.配置本地APIC定时器,div by 16，周期模式
+    lapic_write(LAPIC_TIMER_DIV, 0b0011);
+    lapic_write(LAPIC_LVT_TIMER, (1u << 17) | 0xF0);
+    lapic_write(LAPIC_TIMER_INITCNT, 0x10000);
 
     sti();
 

--- a/oskernel64/kernel/idt.c
+++ b/oskernel64/kernel/idt.c
@@ -114,6 +114,12 @@ void isr_dispatch_c(isr_frame* f) {
             asm volatile("mov %%cr2, %0" : "=r"(cr2));
             printk("  CR2=%x\n", (unsigned long long)cr2);
             die_halt("#PF",f);
+        case 0xF0:
+            apic_timer_isr_c();
+            return;
+        case 0xFE:
+            apic_error_isr_c();
+            return;
         default:
             if (vec >= 0x20) {//外部中断
                 apic_eoi();

--- a/oskernel64/kernel/isr.asm
+++ b/oskernel64/kernel/isr.asm
@@ -51,6 +51,8 @@ make_isr_stub      0x18   ;/* (Reserved) 保留，无 error-code */
 make_isr_stub      0x19   ;/* (Reserved) 保留，无 error-code */
 make_isr_stub      0x1A   ;/* (Reserved) 保留，无 error-code */
 make_isr_stub      0x1B   ;/* (Reserved) 保留，无 error-code */
+make_isr_stub      0xF0   ;/* Local APIC timer */
+make_isr_stub      0xFE   ;/* Local APIC error */
 
 %macro PUSH_GPRS 0
     push rax
@@ -116,7 +118,7 @@ isr_common_entry:
     jz .Lno_swap_exit
     swapgs
 .Lno_swap_exit:
-    POP_GORS
+    POP_GPRS
     add rsp,16
     iretq
 
@@ -148,7 +150,7 @@ isr_common_entry_err:
     jz .Lno_swap_exit_e
     swapgs
 .Lno_swap_exit_e:
-    POP_GRPS
+    POP_GPRS
     add rsp,16
     iretq
 


### PR DESCRIPTION
## Summary
- Add APIC timer and error interrupt stubs
- Initialize local APIC and configure periodic timer
- Dispatch APIC timer/error interrupts in IDT

## Testing
- `make all` *(fails: oskernel/boot/boot.asm:3: unable to open include file `/home/ljw/CLionProjects/test1/oskernel/boot/common.data`)*

------
https://chatgpt.com/codex/tasks/task_e_68a87139bb4883339c32f5113d6166cb